### PR TITLE
Add a line to remove containers in the 'Dead' status before docker-gc runs.

### DIFF
--- a/roles/docker-cleanup/files/docker-cleanup.service
+++ b/roles/docker-cleanup/files/docker-cleanup.service
@@ -7,6 +7,7 @@ ConditionPathExists=/etc/docker-gc-exclude-containers
 Type=oneshot
 ExecStartPre=-/usr/bin/docker rm -v docker-gc
 ExecStartPre=/bin/echo "Starting disk usage" ; /bin/df -h
+ExecStart=-/usr/bin/bash -c "/usr/bin/docker rm $(/usr/bin/docker ps -qaf 'status=dead')"
 ExecStart=/usr/bin/docker run --name docker-gc -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc spotify/docker-gc
 ExecStart=-/usr/bin/bash -c "/usr/bin/docker rmi $(/usr/bin/docker images -q -f 'dangling=true')"
 ExecStart=/usr/bin/docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes

--- a/roles/docker-cleanup/files/docker-cleanup.service
+++ b/roles/docker-cleanup/files/docker-cleanup.service
@@ -7,7 +7,7 @@ ConditionPathExists=/etc/docker-gc-exclude-containers
 Type=oneshot
 ExecStartPre=-/usr/bin/docker rm -v docker-gc
 ExecStartPre=/bin/echo "Starting disk usage" ; /bin/df -h
-ExecStart=-/usr/bin/bash -c "/usr/bin/docker rm $(/usr/bin/docker ps -qaf 'status=dead')"
+ExecStart=-/usr/bin/bash -c "/usr/bin/docker rm -v $(/usr/bin/docker ps -qaf 'status=dead')"
 ExecStart=/usr/bin/docker run --name docker-gc -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc spotify/docker-gc
 ExecStart=-/usr/bin/bash -c "/usr/bin/docker rmi $(/usr/bin/docker images -q -f 'dangling=true')"
 ExecStart=/usr/bin/docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes


### PR DESCRIPTION
This status messes up its operation and those containers are marked for removal anyway (they cannot be restarted).
